### PR TITLE
feat: support `sim()` in top-level asyncio (e.g. jupyter)

### DIFF
--- a/VlsirTools/setup.py
+++ b/VlsirTools/setup.py
@@ -32,6 +32,7 @@ setup(
         f"vlsir=={_VLSIR_VERSION}",  # VLSIR Core Python Bindings
         "numpy==1.21.5",  # For `sim_data` simulation results
         "pandas",  # For CSV reading
+        "nest_asyncio",  # To make life with asyncio easier (e.g. in Jupyter)
     ],
     extras_require={
         "dev": ["pytest==7.1", "coverage", "pytest-cov", "black==22.6", "twine"]

--- a/VlsirTools/tests/test_vlsirtools.py
+++ b/VlsirTools/tests/test_vlsirtools.py
@@ -598,7 +598,6 @@ def test_sim_async():
 
     asyncio.run(an_async_caller())
 
-
 @pytest.mark.ngspice
 def test_sim_async_in_existing_loop():
     async def _main_async():
@@ -609,6 +608,7 @@ def test_sim_async_in_existing_loop():
                 AnalysisType.AC,  ## FIXME: ac, we don't wanna skip, but parses crazy 10**271 imaginary numbers(?)
             ],
         )
-
+        
     # simulating a top-level asyncio loop (e.g. in a Jupyter notebook)
     assert asyncio.run(_main_async()) is not None
+    

--- a/VlsirTools/tests/test_vlsirtools.py
+++ b/VlsirTools/tests/test_vlsirtools.py
@@ -598,6 +598,7 @@ def test_sim_async():
 
     asyncio.run(an_async_caller())
 
+
 @pytest.mark.ngspice
 def test_sim_async_in_existing_loop():
     async def _main_async():
@@ -608,7 +609,6 @@ def test_sim_async_in_existing_loop():
                 AnalysisType.AC,  ## FIXME: ac, we don't wanna skip, but parses crazy 10**271 imaginary numbers(?)
             ],
         )
-        
+
     # simulating a top-level asyncio loop (e.g. in a Jupyter notebook)
     assert asyncio.run(_main_async()) is not None
-    

--- a/VlsirTools/tests/test_vlsirtools.py
+++ b/VlsirTools/tests/test_vlsirtools.py
@@ -597,3 +597,18 @@ def test_sim_async():
         )
 
     asyncio.run(an_async_caller())
+
+@pytest.mark.ngspice
+def test_sim_async_in_existing_loop():
+    async def _main_async():
+        return dummy_sim_tests(
+            SupportedSimulators.NGSPICE,
+            skip=[
+                AnalysisType.DC,  ## DC is skipped on purpose; ngspice doesn't support this kinda sweep
+                AnalysisType.AC,  ## FIXME: ac, we don't wanna skip, but parses crazy 10**271 imaginary numbers(?)
+            ],
+        )
+        
+    # simulating a top-level asyncio loop (e.g. in a Jupyter notebook)
+    assert asyncio.run(_main_async()) is not None
+    

--- a/VlsirTools/vlsirtools/spice/spice.py
+++ b/VlsirTools/vlsirtools/spice/spice.py
@@ -92,13 +92,14 @@ def sim(
     else:
         # otherwise we using threading to get around the asyncio nesting restriction
         result = []
+
         def target():
             result.append(asyncio.run(sim_async(inp, opts)))
+
         thread = threading.Thread(target=target)
         thread.start()
         thread.join()
         return result[0]
-        
 
 
 async def sim_async(

--- a/VlsirTools/vlsirtools/spice/spice.py
+++ b/VlsirTools/vlsirtools/spice/spice.py
@@ -8,7 +8,6 @@ from typing import Union, Optional, Sequence, Awaitable, TypeVar
 from enum import Enum
 from textwrap import dedent
 from dataclasses import dataclass, field
-import threading
 
 # Local/ Project Dependencies
 import vlsir.spice_pb2 as vsp
@@ -87,10 +86,11 @@ def sim(
         loop = asyncio.get_running_loop()
     except RuntimeError:
         loop = None
-        
+
     if loop is not None:
         # patch asyncio to allow nested event loops
         import nest_asyncio
+
         nest_asyncio.apply(loop)
 
     return asyncio.run(sim_async(inp, opts))


### PR DESCRIPTION
A hacky way to get around nested asyncio. Not the best practice for sure but does the job.

An alternative is to use `https://github.com/erdewit/nest_asyncio` but it introduces extra dependency.

Or we can stick to the practice to always asyncio so this async to sync transition doesn't exist.