### PR TITLE
Replace `asyncio` with `concurrent.futures`

### DIFF
--- a/VlsirTools/readme.md
+++ b/VlsirTools/readme.md
@@ -20,7 +20,7 @@ class SupportedSimulators(Enum):
     NGSPICE = "ngspice"
 ```
 
-The primary entry-point for simulation is `vlsirtools.spice.sim`. 
+The primary entry-point for simulation is `vlsirtools.spice.sim`. By default, `sim` runs your chosen simulator in parallel over the list of `SimInputs` provided as `inp`.
 
 ```python
 def sim(
@@ -29,7 +29,6 @@ def sim(
 ```
 
 The `sim` function takes as input one or more `vlsir.spice.SimInput`s and a set of simulation options (`vlsirtools.spice.SimOptions`), and returns one of two result-types depending on its input `options`.
-
 
 ```python
 class ResultFormat(Enum):
@@ -40,18 +39,6 @@ class ResultFormat(Enum):
 ```
 
 The `VLSIR_PROTO` result-format returns a `vlsir.spice.SimResult` object, which is a protobuf-encoded representation of the simulation results. The `SIM_DATA` format instead uses the types defined in `vlsirtools.spice.sim_data`, a python-native combination of dataclasses and numpy arrays. The former is generally more convenient for sharing with other programs, and the latter for further in-Python processing. 
-
-Simulations can be invoked asynchronously by instead invoking `vlsirtools.spice.sim_async`. 
-Its interface is identical to `vlsirtools.spice.sim`, but for returning an `Awaitable`. 
-
-```python
-async def sim_async(
-    inp: OneOrMore[vsp.SimInput], opts: Optional[SimOptions] = None
-) -> Awaitable[OneOrMore[SimResultUnion]]:
-```
-
-Asynchronously invoking simulation is particularly valuable for large batches of simulations, 
-e.g. for "corner" or other parametric variations, as the simulator invocations can be run in parallel.
 
 ### Simulator and Analysis Support
 

--- a/VlsirTools/setup.py
+++ b/VlsirTools/setup.py
@@ -32,7 +32,6 @@ setup(
         f"vlsir=={_VLSIR_VERSION}",  # VLSIR Core Python Bindings
         "numpy==1.21.5",  # For `sim_data` simulation results
         "pandas",  # For CSV reading
-        # FIXME: "nest_asyncio",  # To make life with asyncio easier (e.g. in Jupyter)
     ],
     extras_require={
         "dev": ["pytest==7.1", "coverage", "pytest-cov", "black==22.6", "twine"]

--- a/VlsirTools/tests/test_vlsirtools.py
+++ b/VlsirTools/tests/test_vlsirtools.py
@@ -4,7 +4,7 @@ Unit Tests
 """
 
 import numpy as np
-import pytest, asyncio
+import pytest
 from io import StringIO
 from typing import Dict, List, Optional
 
@@ -28,7 +28,6 @@ from vlsirtools.spice import (
     SimOptions,
     ResultFormat,
     sim,
-    sim_async,
 )
 import vlsirtools.spice.sim_data as sd
 from vlsirtools.spice.sim_data import AnalysisType
@@ -631,42 +630,3 @@ def test_noise1():
             simulator=SupportedSimulators.NGSPICE, fmt=ResultFormat.SIM_DATA
         ),
     )
-
-
-@pytest.mark.ngspice
-def test_sim_async():
-    """Test the async version of `sim`, and what a basic asynchronous caller needs to look like."""
-
-    def an_async_caller() -> sd.SimResult:
-        """# An async function which will call `sim_async`.
-        The real point here: the `return await` part, for any async caller."""
-
-        return sim_async(
-            inp=dummy_sim(
-                skip=[
-                    AnalysisType.DC,  ## DC is skipped on purpose; ngspice doesn't support this kinda sweep
-                    AnalysisType.AC,  ## FIXME: ac, we don't wanna skip, but parses crazy 10**271 imaginary numbers(?)
-                ],
-            ),
-            opts=SimOptions(
-                simulator=SupportedSimulators.NGSPICE, fmt=ResultFormat.SIM_DATA
-            ),
-        )
-
-    asyncio.run(an_async_caller())
-
-
-@pytest.mark.xfail(reason="https://github.com/Vlsir/Vlsir/issues/56")
-@pytest.mark.ngspice
-def test_sim_async_in_existing_loop():
-    async def _main_async():
-        return dummy_sim_tests(
-            SupportedSimulators.NGSPICE,
-            skip=[
-                AnalysisType.DC,  ## DC is skipped on purpose; ngspice doesn't support this kinda sweep
-                AnalysisType.AC,  ## FIXME: ac, we don't wanna skip, but parses crazy 10**271 imaginary numbers(?)
-            ],
-        )
-
-    # simulating a top-level asyncio loop (e.g. in a Jupyter notebook)
-    assert asyncio.run(_main_async()) is not None

--- a/VlsirTools/vlsirtools/spice/base.py
+++ b/VlsirTools/vlsirtools/spice/base.py
@@ -3,7 +3,7 @@
 """
 
 # Std-Lib Imports
-import asyncio, os, tempfile
+import subprocess, os, tempfile
 from typing import Optional, Awaitable, List, IO
 from pathlib import Path
 
@@ -42,7 +42,7 @@ class Sim:
         raise NotImplementedError
 
     @classmethod
-    async def sim(
+    def sim(
         cls, inp: vsp.SimInput, opts: Optional[SimOptions] = None
     ) -> Awaitable[SimResultUnion]:
         """Sim-invoking class method.
@@ -56,7 +56,7 @@ class Sim:
         sim = cls(inp=inp, opts=opts)
         try:
             sim.setup()
-            results = await sim.run()
+            results = sim.run()
         finally:
             sim.cleanup()
 
@@ -75,7 +75,7 @@ class Sim:
         self.opts = opts
         self.rundir = opts.rundir
         self.tmpdir: Optional[tempfile.TemporaryDirectory] = None
-        self.subprocesses: List[asyncio.Process] = []
+        self.subprocesses: List[subprocess.Process] = []
 
     def setup(self):
         """Perform simulation setup, including the simulation directory and top-level Module validation."""
@@ -95,18 +95,18 @@ class Sim:
         if self.tmpdir is not None:
             self.tmpdir.cleanup()
 
-    async def run_subprocess(self, cmd: str) -> Awaitable[None]:
+    def run_subprocess(self, cmd: str) -> Awaitable[None]:
         """Asynchronously run a shell subprocess invoking command `cmd`.
         All subprocesses are run in `self.rundir`, and tracked in the list `self.subprocesses`."""
 
-        proc = await asyncio.create_subprocess_shell(
+        proc = subprocess.Popen(
             cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             cwd=str(self.rundir),
         )
         self.subprocesses.append(proc)
-        stdout, stderr = await proc.communicate()
+        stdout, stderr = proc.communicate()
 
         # The async subprocess module does not raise Python exceptions: check the return code instead.
         if proc.returncode != 0:

--- a/VlsirTools/vlsirtools/spice/base.py
+++ b/VlsirTools/vlsirtools/spice/base.py
@@ -4,7 +4,7 @@
 
 # Std-Lib Imports
 import subprocess, os, tempfile
-from typing import Optional, Awaitable, List, IO
+from typing import Optional, List, IO
 from pathlib import Path
 
 # Local/ Project Dependencies
@@ -44,7 +44,7 @@ class Sim:
     @classmethod
     def sim(
         cls, inp: vsp.SimInput, opts: Optional[SimOptions] = None
-    ) -> Awaitable[SimResultUnion]:
+    ) -> SimResultUnion:
         """Sim-invoking class method.
         Creates an instance of `cls` as a context manager, run in its simulation directory.
         This should be invoked by typical implementations of a free-standing `sim` function."""
@@ -67,7 +67,7 @@ class Sim:
             return results.to_proto()
         return results
 
-    def run(self) -> Awaitable[SimResultUnion]:
+    def run(self) -> SimResultUnion:
         raise NotImplementedError("`Sim` subclasses must implement `run`")
 
     def __init__(self, inp: vsp.SimInput, opts: SimOptions) -> None:
@@ -95,8 +95,8 @@ class Sim:
         if self.tmpdir is not None:
             self.tmpdir.cleanup()
 
-    def run_subprocess(self, cmd: str) -> Awaitable[None]:
-        """Asynchronously run a shell subprocess invoking command `cmd`.
+    def run_subprocess(self, cmd: str) -> None:
+        """Run a shell subprocess invoking command `cmd`.
         All subprocesses are run in `self.rundir`, and tracked in the list `self.subprocesses`."""
 
         proc = subprocess.Popen(
@@ -108,7 +108,7 @@ class Sim:
         self.subprocesses.append(proc)
         stdout, stderr = proc.communicate()
 
-        # The async subprocess module does not raise Python exceptions: check the return code instead.
+        # The subprocess module does not raise Python exceptions: check the return code instead.
         if proc.returncode != 0:
             from . import SimError
 

--- a/VlsirTools/vlsirtools/spice/ngspice.py
+++ b/VlsirTools/vlsirtools/spice/ngspice.py
@@ -8,7 +8,8 @@ import subprocess, re, shutil
 from enum import Enum
 from warnings import warn
 from dataclasses import dataclass
-from typing import Mapping, IO, Dict, Awaitable
+from typing import Mapping, IO, Dict
+import shlex
 
 # External Imports
 import numpy as np
@@ -196,10 +197,10 @@ class NGSpiceSim(Sim):
             warn(msg)
         return parse_mt0(self.open(meas_files[0], "r"))
 
-    def run_sim_process(self) -> Awaitable[None]:
+    def run_sim_process(self) -> None:
         """Run a NGSpice sub-process, executing the simulation"""
         # Note the `nutbin` output format is dictated here
-        cmd = f"{NGSPICE_EXECUTABLE} -b netlist.sp -r netlist.raw".split(" ")
+        cmd = shlex.split(f"{NGSPICE_EXECUTABLE} -b netlist.sp -r netlist.raw")
         return self.run_subprocess(cmd)
 
 

--- a/VlsirTools/vlsirtools/spice/spectre.py
+++ b/VlsirTools/vlsirtools/spice/spectre.py
@@ -15,11 +15,7 @@ import vlsir.spice_pb2 as vsp
 from ..netlist.spectre import SpectreNetlister
 from .base import Sim
 from .sim_data import TranResult, OpResult, SimResult, AcResult, DcResult
-from .spice import (
-    SupportedSimulators,
-    sim,
-    sim_async,  # Not directly used here, but "re-exported"
-)
+from .spice import SupportedSimulators, sim
 
 # Module-level configuration. Over-writeable by sufficiently motivated users.
 
@@ -63,14 +59,14 @@ class SpectreSim(Sim):
     def enum(cls) -> SupportedSimulators:
         return SupportedSimulators.SPECTRE
 
-    async def run(self) -> Awaitable[SimResult]:
+    def run(self) -> Awaitable[SimResult]:
         """Run the specified `SimInput` in directory `self.rundir`, returning its results."""
 
         # Write our netlist to file
         self.write_netlist()
 
         # Run the simulation
-        await self.run_spectre_process()
+        self.run_spectre_process()
 
         # Parse the results
         return self.parse_results()
@@ -164,7 +160,7 @@ class SpectreSim(Sim):
     def run_spectre_process(self) -> Awaitable[None]:
         """Run a Spectre sub-process, executing the simulation"""
         # Note the `nutbin` output format is dictated here
-        cmd = f"{SPECTRE_EXECUTABLE} {SPECTRE_ARGS} -E -format nutbin netlist.scs"
+        cmd = f"{SPECTRE_EXECUTABLE} {SPECTRE_ARGS} -E -format nutbin netlist.scs".split(" ")
         return self.run_subprocess(cmd)
 
 

--- a/VlsirTools/vlsirtools/spice/spectre.py
+++ b/VlsirTools/vlsirtools/spice/spectre.py
@@ -160,7 +160,11 @@ class SpectreSim(Sim):
     def run_spectre_process(self) -> Awaitable[None]:
         """Run a Spectre sub-process, executing the simulation"""
         # Note the `nutbin` output format is dictated here
-        cmd = f"{SPECTRE_EXECUTABLE} {SPECTRE_ARGS} -E -format nutbin netlist.scs".split(" ")
+        cmd = (
+            f"{SPECTRE_EXECUTABLE} {SPECTRE_ARGS} -E -format nutbin netlist.scs".split(
+                " "
+            )
+        )
         return self.run_subprocess(cmd)
 
 

--- a/VlsirTools/vlsirtools/spice/spectre.py
+++ b/VlsirTools/vlsirtools/spice/spectre.py
@@ -5,7 +5,7 @@ Spectre Implementation of `vlsir.spice.Sim`
 # Std-Lib Imports
 import subprocess, re, shutil, glob
 import numpy as np
-from typing import Tuple, Any, Mapping, Optional, IO, Dict, Awaitable
+from typing import Tuple, Any, Mapping, Optional, IO, Dict
 from dataclasses import dataclass
 from warnings import warn
 from enum import Enum
@@ -59,7 +59,7 @@ class SpectreSim(Sim):
     def enum(cls) -> SupportedSimulators:
         return SupportedSimulators.SPECTRE
 
-    def run(self) -> Awaitable[SimResult]:
+    def run(self) -> SimResult:
         """Run the specified `SimInput` in directory `self.rundir`, returning its results."""
 
         # Write our netlist to file
@@ -157,7 +157,7 @@ class SpectreSim(Sim):
             warn(msg)
         return parse_mt0(self.open(meas_files[0], "r"))
 
-    def run_spectre_process(self) -> Awaitable[None]:
+    def run_spectre_process(self) -> None:
         """Run a Spectre sub-process, executing the simulation"""
         # Note the `nutbin` output format is dictated here
         cmd = (

--- a/VlsirTools/vlsirtools/spice/spice.py
+++ b/VlsirTools/vlsirtools/spice/spice.py
@@ -5,7 +5,7 @@
 # Std-Lib Imports
 import os, subprocess
 import concurrent.futures
-from typing import Union, Optional, Sequence, Awaitable, TypeVar
+from typing import Union, Optional, Sequence, TypeVar
 from enum import Enum
 from textwrap import dedent
 from dataclasses import dataclass, field
@@ -77,9 +77,9 @@ OneOrMore = Union[T, Sequence[T]]
 
 def sim(
     inp: OneOrMore[vsp.SimInput], opts: Optional[SimOptions] = None
-) -> Awaitable[OneOrMore[SimResultUnion]]:
+) -> OneOrMore[SimResultUnion]:
     """
-    Asynchronously execute one or more `vlir.spice.Sim`.
+    Concurrently execute one or more `vlir.spice.Sim`.
     Dispatches across `SupportedSimulators` specified in `SimOptions` `opts`.
     Uses the default `Simulator` as detected by the `default` method if no `simulator` is specified.
     """


### PR DESCRIPTION
Resolves:

- https://github.com/Vlsir/Vlsir/issues/56
- https://github.com/Vlsir/Vlsir/issues/61
- https://github.com/dan-fritchman/Hdl21/issues/122

Twinned with:

- https://github.com/dan-fritchman/Hdl21/pull/143

Major changes:

- Scrub `asyncio` from VLSIR and deprecate any `*_async` functions
- Use `concurrent.futures.ThreadPoolExecutor` for multithreading in both `spice.py` and `xyce.py`
- Removed `async` tests, did not replace with new tests for parallelism