### PR TITLE
allow python3.12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout VLSIR Repo

--- a/VlsirTools/setup.py
+++ b/VlsirTools/setup.py
@@ -27,7 +27,7 @@ setup(
     author="Dan Fritchman",
     author_email="dan@fritch.mn",
     packages=find_packages(),
-    python_requires=">=3.7, <3.12",
+    python_requires=">=3.7, <3.13",
     install_requires=[
         f"vlsir=={VLSIR_VERSION}",  # VLSIR Core Python Bindings
         "numpy~=1.21",  # For `sim_data` simulation results

--- a/VlsirTools/setup.py
+++ b/VlsirTools/setup.py
@@ -30,8 +30,8 @@ setup(
     python_requires=">=3.7, <3.13",
     install_requires=[
         f"vlsir=={VLSIR_VERSION}",  # VLSIR Core Python Bindings
-        "numpy~=1.21",  # For `sim_data` simulation results
-        "pandas~=1.3",  # For CSV reading
+        "numpy",  # For `sim_data` simulation results
+        "pandas",  # For CSV reading
     ],
     extras_require={"dev": ["vlsirdev"]},
 )


### PR DESCRIPTION
This PR updates the latest versions of numpy, python and pandas

- allow python3.12, which is the main used now
- unpin old numpy and pandas

fixes https://github.com/Vlsir/Vlsir/issues/97

@dan-fritchman 
@hpretl 