### PR TITLE
Python 3.12 CI Fix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: tests
 
 on:
@@ -26,7 +23,15 @@ jobs:
           apt-get install -y python${{ matrix.python-version }}
           apt-get install -y python${{ matrix.python-version }}-dev
           apt-get install -y python${{ matrix.python-version }}-venv
-          apt-get install -y python${{ matrix.python-version }}-distutils
+          # Only install distutils for Python versions below 3.12
+          if [[ "${{ matrix.python-version }}" < "3.12" ]]; then
+            apt-get install -y python${{ matrix.python-version }}-distutils || true
+          fi
+          # For Python 3.12, install setuptools which replaces distutils functionality
+          if [[ "${{ matrix.python-version }}" > "3.11" ]]; then
+            python${{ matrix.python-version }} -m ensurepip --upgrade || true
+            python${{ matrix.python-version }} -m pip install setuptools
+          fi
 
       #! The bizarre insanity of ". ./venv/..." is an Ubuntu sh translation of
       #! "source venv/..." seen in most Python documentation


### PR DESCRIPTION
#101 Yup, 3.12 doesn't have distutils so pip panics when we ask it to install some, the specific script also doesn't look distutils in 3.13 - so hopefully this won't need another fix.