### PR TITLE
Allow newer versions of the Python protobuf dependency

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -38,7 +38,7 @@ setup(
         # Most binding-code is *not* generated per-schema, but is in the protobuf package,
         # And schema-derived types are generated on the fly.
         # So, versions before this will generally fail pretty hard.
-        "protobuf~=4.23"
+        "protobuf>=4.23"
     ],
     extras_require={"dev": ["vlsirdev"]},
 )


### PR DESCRIPTION
We have an issue when building our https://github.com/iic-jku/IIC-OSIC-TOOLS
as the Python version is quite old and unmaintained (according to https://protobuf.dev/support/version-support/#python).

This just adds the dependency requirement line that was already relaxed in https://github.com/Vlsir/Vlsir/issues/106,
but additionally insures that an old incompatible version is avoided.