### PR TITLE
#110: robust nutbin parsing for ngspice and spectre

### DIFF
--- a/VlsirTools/tests/test_vlsirtools.py
+++ b/VlsirTools/tests/test_vlsirtools.py
@@ -643,7 +643,6 @@ def test_noise1():
 def test_ngspice_forward_flags():
     """# Regression test for #110
     Handle extra flags like 'forward' in nutbin output."""
-    import os
     from vlsirtools.spice.ngspice import parse_nutbin_analysis, NumType
 
     # A mock "nutbin" file content with the problematic "Flags: real forward"

--- a/VlsirTools/tests/test_vlsirtools.py
+++ b/VlsirTools/tests/test_vlsirtools.py
@@ -656,8 +656,7 @@ def test_ngspice_forward_flags():
         b"No. Points: 1\n"
         b"Variables:\n"
         b"\t0\tv(1)\tvoltage\n"
-        b"Binary:\n"
-        + np.array([1.0], dtype="<f8").tobytes()
+        b"Binary:\n" + np.array([1.0], dtype="<f8").tobytes()
     )
 
     fname = "test_ngspice_forward_flags.raw"
@@ -715,4 +714,6 @@ write ./test.raw
         assert results, "No results parsed from nutbin file"
         for analysis, res in results.items():
             assert hasattr(res, "data"), "Parsed result missing data field"
-            assert any(len(arr) > 0 for arr in res.data.values()), "No data in parsed result"
+            assert any(
+                len(arr) > 0 for arr in res.data.values()
+            ), "No data in parsed result"

--- a/VlsirTools/vlsirtools/spice/ngspice.py
+++ b/VlsirTools/vlsirtools/spice/ngspice.py
@@ -267,38 +267,67 @@ def parse_nutbin(f: IO) -> Mapping[str, NutBinAnalysis]:
     Returns results as a dictionary from `analysis_name` to `NutBinAnalysis`.
     Note this is paired with the simulator invocation commands, which include `format=nutbin`."""
 
-    # Parse per-file header info
-    # First 2 lines are ascii one line statements
-
-    # And parse the rest of the file per-analysis
+    # And parse the file per-analysis
     rv = {}
-    while f:
-        _title = f.readline()  # Title, ignored
-        _date = f.readline()  # Run date, ignored
-        plotname = f.readline().decode("ascii")  # Simulation name
-        if len(plotname) == 0:
+    while True:
+        line = f.readline()
+        if not line:
             break
-        an = parse_nutbin_analysis(f, plotname)
-        rv[an.analysis_name] = an
+        # Headers like Title, Date, and Command often precede the first Plotname.
+        # Some versions repeat them per-plot; some do not.
+        # We skip everything until we find a `Plotname` line.
+        line_str = line.decode("ascii")
+        if line_str.startswith("Plotname:"):
+            an = parse_nutbin_analysis(f, line_str)
+            rv[an.analysis_name] = an
     return rv
 
 
 def parse_nutbin_analysis(f: IO, plotname: str) -> NutBinAnalysis:
     """Parse a `NutBinAnalysis` from an open nutbin-format file `f`."""
 
-    # Next 4 lines are also ascii one line statements
     # Parse the `Flags` field, which primarily includes the numeric datatype
-    flags = f.readline().decode("ascii")
-    flags = flags.split()
-    if len(flags) != 2 or flags[0] != "Flags:":
+    # Skip any other header lines until we find it.
+    while True:
+        flags_line = f.readline().decode("ascii")
+        if not flags_line:
+            raise ValueError(f"Could not find Flags line for plot {plotname}")
+        if flags_line.startswith("Flags:"):
+            break
+
+    flags = flags_line.split()
+
+    # The numeric type is expected to be either 'real' or 'complex'
+    # We've seen this take a few forms, e.g. `Flags: real` or `Flags: complex`
+    # Some versions / analyses appear to add more, e.g. `Flags: real forward`
+    if "real" in flags:
+        numtype = NumType.REAL
+    elif "complex" in flags:
+        numtype = NumType.COMPLEX
+    elif len(flags) > 1:
+        # Fallback for any other types we might have missed
+        numtype = NumType.from_str(flags[1])
+    else:
         raise ValueError(f"Invalid flags {flags}")
-    numtype = NumType.from_str(flags[1])
+
     nptypes = {NumType.REAL: float, NumType.COMPLEX: complex}
     nptype = nptypes[numtype]
 
     # Parse the number of variables and points
-    num_vars_line = f.readline()  # No. Variables:   [nvar]
-    num_pts_line = f.readline()  # No. Points:      [npts]
+    # Skip any other header lines until we find them.
+    while True:
+        num_vars_line = f.readline()
+        if not num_vars_line:
+            raise ValueError(f"Could not find No. Variables line for plot {plotname}")
+        if num_vars_line.decode("ascii").startswith("No. Variables:"):
+            break
+    while True:
+        num_pts_line = f.readline()
+        if not num_pts_line:
+            raise ValueError(f"Could not find No. Points line for plot {plotname}")
+        if num_pts_line.decode("ascii").startswith("No. Points:"):
+            break
+
     sim_name = plotname.split("`")[-1].split("'")[0]
 
     # Find the number of variables and number of points
@@ -317,14 +346,25 @@ def parse_nutbin_analysis(f: IO, plotname: str) -> NutBinAnalysis:
 
     # Decode the variables spec, looks like the following
     # Variables: [Variable idx] [Variable name] [units] [optional_flags]
-    f.readline()
+    while True:
+        line = f.readline().decode("ascii")
+        if not line:
+            raise ValueError(f"Could not find Variables: line for plot {plotname}")
+        if line.startswith("Variables:"):
+            break
+
     var_specs = []
     for i in range(num_vars):
         var_specs.append(_read_var_spec(f.readline().decode("ascii")))
 
     # Read the binary data, should look like the following:
     # Binary: \n[Binary data]
-    binary_line = f.readline().decode("ascii")
+    while True:
+        binary_line = f.readline().decode("ascii")
+        if not binary_line:
+            raise ValueError(f"Could not find Binary: line for plot {plotname}")
+        if binary_line.startswith("Binary:"):
+            break
     assert binary_line == "Binary:\n"
     # Data is big endian
     bin_data = np.fromfile(

--- a/bindings/python/vlsir/__init__.py
+++ b/bindings/python/vlsir/__init__.py
@@ -5,7 +5,7 @@ Note while most modules in this package are protobuf-compiler generated,
 *this* top-level namespace module is not! 
 """
 
-__version__ = "7.0.0" # VLSIR_VERSION
+__version__ = "7.0.0"  # VLSIR_VERSION
 
 # Schema
 from . import utils_pb2 as utils


### PR DESCRIPTION
This PR fixes issue #110 where the nutbin binary result parser was sensitive to the number of header lines and the specific formatting of flags. This was most notably triggered by recent [ngspice versions (v42+)](https://ngspice.sourceforge.io/news.html) adding a Command: header line and including sweep metadata in the `Flags: field` (e.g., `Flags: real forward`).

Example:

```python
tests/test_vlsirtools.py:673: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
vlsirtools/spice/ngspice.py:281: in parse_nutbin
    an = parse_nutbin_analysis(f, plotname)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

f = <_io.BufferedReader name='/tmp/tmp6jj05k0r/test.raw'>
plotname = 'Command: ngspice-45.2, Build Wed Jan  7 16:47:31 UTC 2026\n'

    def parse_nutbin_analysis(f: IO, plotname: str) -> NutBinAnalysis:
        """Parse a `NutBinAnalysis` from an open nutbin-format file `f`."""
    
        # Next 4 lines are also ascii one line statements
        # Parse the `Flags` field, which primarily includes the numeric datatype
        flags = f.readline().decode("ascii")
        flags = flags.split()
        if len(flags) != 2 or flags[0] != "Flags:":
>           raise ValueError(f"Invalid flags {flags}")
E           ValueError: Invalid flags ['Plotname:', 'Operating', 'Point']
```

### Changes

1. **Robust Header Parsing**: Rewrote the nutbin parser in both [ngspice.py](VlsirTools/vlsirtools/spice/ngspice.py) and [spectre.py](VlsirTools/vlsirtools/spice/spectre.py) to search for specific field labels (like Flags:, No. Variables:, and Binary:) instead of relying on fixed line offsets.

2. **Improved Flag Detection**: Changed the numeric type check (real vs complex) to use keyword membership instead of strict equality. This allows the parser to correctly handle cases where simulators include additional metadata in the flags.

3. **Symmetry Upgrades**: Applied identical logic to the Spectre parser, as it shares the NutBin format and would suffer from similar fragility if Spectre's output headers evolve.

4. **Regression Testing**: Added `test_ngspice_forward_flags` and `test_integration_ngspice_nutbin` to the VlsirTools test suite, which mocks a raw file containing multi-word flags and then tests this with ngspice-45.2.

### Verification

- Verified by upgrading the local environment to ngspice-45.2 and confirming that the legacy parser failed while the new parser succeeded.
- Copilot successfully ran manual simulations with both single and multiple analysis plots.

### Related PRs

Refurbished VLSIR Test-Container https://github.com/Vlsir/vlsir-test-container/pull/2

